### PR TITLE
Fix navigation support button

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -9,6 +9,7 @@ describe("Sidebar Navigation", () => {
     });
 
     it("links are working", () => {
+      const supportEmail = "support@prolog-app.com";
       // check that each link leads to the correct page
       cy.get("nav")
         .contains("Projects")
@@ -29,6 +30,19 @@ describe("Sidebar Navigation", () => {
       cy.get("nav")
         .contains("Settings")
         .should("have.attr", "href", "/dashboard/settings");
+
+      cy.window().then((win) => {
+        cy.stub(win, "open").as("windowOpen");
+      });
+
+      cy.get('img[alt="Support icon"]').click();
+
+      cy.window()
+        .its("open")
+        .should(
+          "be.calledWithMatch",
+          `mailto:${supportEmail}?subject=Support Request: `,
+        );
     });
 
     it("is collapsible", () => {

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -86,7 +86,7 @@ export function SidebarNavigation() {
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() =>
-                (window.location.href = `mailto:${supportEmail}?subject=Support Request: `)
+                window.open(`mailto:${supportEmail}?subject=Support Request: `)
               }
             />
             <MenuItemButton

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -16,6 +16,8 @@ const menuItems = [
   { text: "Settings", iconSrc: "/icons/settings.svg", href: Routes.settings },
 ];
 
+const supportEmail = "support@prolog-app.com";
+
 export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
@@ -83,7 +85,7 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() => (window.location.href = `mailto:${supportEmail}`)}
             />
             <MenuItemButton
               text="Collapse"

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -85,7 +85,9 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => (window.location.href = `mailto:${supportEmail}`)}
+              onClick={() =>
+                (window.location.href = `mailto:${supportEmail}?subject=Support Request: `)
+              }
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Clicking on support button will now open users preferred email client with predefined email & subject. Implemented test to test the buttons functionality.