### PR TITLE
Refactor hardcoded breakpoint

### DIFF
--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -16,5 +16,18 @@ module.exports = {
         ],
       },
     ],
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        ignorePseudoClasses: ["export"],
+      },
+    ],
+    "property-no-unknown": [
+      true,
+      {
+        ignoreProperties: ["desktop"],
+        ignoreSelectors: [":export"],
+      },
+    ],
   },
 };

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -6,16 +6,6 @@ module.exports = {
     "selector-class-pattern":
       "^([a-z][a-zA-Z]*)(-[a-z][a-zA-Z]*)*$|^([a-z][a-zA-Z]*)+$",
     // allow CSS modules "composes" proptery
-    "property-no-unknown": [
-      true,
-      {
-        ignoreProperties: [
-          // CSS Modules composition
-          // https://github.com/css-modules/css-modules#composition
-          "composes",
-        ],
-      },
-    ],
     "selector-pseudo-class-no-unknown": [
       true,
       {
@@ -25,8 +15,12 @@ module.exports = {
     "property-no-unknown": [
       true,
       {
-        ignoreProperties: ["desktop"],
+        // allow CSS modules "composes" proptery, as well as :export and desktop for breakpoints.
+        ignoreProperties: ["desktop", "composes"],
         ignoreSelectors: [":export"],
+
+        // CSS Modules composition
+        // https://github.com/css-modules/css-modules#composition
       },
     ],
   },

--- a/features/layout/page-container/page-container.module.scss
+++ b/features/layout/page-container/page-container.module.scss
@@ -1,7 +1,7 @@
 @use "@styles/color";
 @use "@styles/font";
 @use "@styles/space";
-@use "@styles/breakpoint";
+@use "@styles/breakpoint.module";
 @use "@styles/misc";
 
 .container {

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -1,6 +1,6 @@
 @use "@styles/color";
 @use "@styles/space";
-@use "@styles/breakpoint";
+@use "@styles/breakpoint.module";
 @use "@styles/z-index";
 @use "@styles/misc";
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -7,6 +7,7 @@ import { MenuItemButton } from "./menu-item-button";
 import { MenuItemLink } from "./menu-item-link";
 import { Button } from "@features/ui";
 import styles from "./sidebar-navigation.module.scss";
+import breakpoints from "@styles/breakpoint.module.scss";
 
 const menuItems = [
   { text: "Projects", iconSrc: "/icons/projects.svg", href: Routes.projects },
@@ -19,13 +20,13 @@ const menuItems = [
 const supportEmail = "support@prolog-app.com";
 
 export function SidebarNavigation() {
-  const [isDesktop, setIsDesktop] = useState(
-    typeof window !== "undefined" ? window.innerWidth >= 64 * 16 : false,
-  );
+  const [isDesktop, setIsDesktop] = useState(false);
 
   useEffect(() => {
+    setIsDesktop(window.innerWidth >= parseFloat(breakpoints.desktop));
+
     const handleResize = () => {
-      setIsDesktop(window.innerWidth >= 64 * 16);
+      setIsDesktop(window.innerWidth >= parseFloat(breakpoints.desktop));
     };
 
     window.addEventListener("resize", handleResize);

--- a/features/projects/components/project-list/project-list.module.scss
+++ b/features/projects/components/project-list/project-list.module.scss
@@ -1,4 +1,4 @@
-@use "@styles/breakpoint";
+@use "@styles/breakpoint.module";
 @use "@styles/space";
 
 .list {

--- a/styles/breakpoint.d.ts
+++ b/styles/breakpoint.d.ts
@@ -1,0 +1,3 @@
+declare module "@styles/breakpoint.module.scss" {
+  export const desktop: string;
+}

--- a/styles/breakpoint.module.scss
+++ b/styles/breakpoint.module.scss
@@ -1,0 +1,5 @@
+$desktop: 1024px;
+
+:export {
+  desktop: $desktop;
+}

--- a/styles/breakpoint.scss
+++ b/styles/breakpoint.scss
@@ -1,1 +1,0 @@
-$desktop: 64em;


### PR DESCRIPTION
Previously the breakpoint was hardcoded in the navigation bar for determining which logo to use (small/large). 
Now it get's the variable from breakpoint.module.scsss.